### PR TITLE
Add missing `minecraft-data` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "deepmerge": "^4.3.0",
         "joi": "^17.6.0",
         "json5": "^2.2.3",
+        "minecraft-data": "^3.0.0",
         "minecraft-protocol": "^1.40.3",
         "mineflayer-antiafk": "github:Etiaro/mineflayer-antiafk",
         "mineflayer-auto-eat": "^3.3.0",
@@ -222,11 +223,6 @@
         "prismarine-item": "^1.11.5",
         "smart-buffer": "^4.2.0"
       }
-    },
-    "node_modules/@rob9315/mcproxy/node_modules/minecraft-data": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-3.19.0.tgz",
-      "integrity": "sha512-qOrgBMIekOblZ6YJGnxzWIDSGJkdLIlrZlRdi3/9MVMV2r80t4Ccq/Tf5azOPmpCetJ2tqbq96oeIG90tV+s6A=="
     },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
@@ -1835,9 +1831,9 @@
       }
     },
     "node_modules/minecraft-data": {
-      "version": "2.221.0",
-      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-2.221.0.tgz",
-      "integrity": "sha512-0AhqzbIKb6WqPSF6qBevaPryeWOz545hLxt6q+gfJF8YIQX/YfkyX/nXWhl+pSIS2rTBcQ0RJkRCtTeRzQwHDA=="
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-3.26.0.tgz",
+      "integrity": "sha512-9DGMM4qI7DdOFTMbtr3Wa/W+XXq11//Lhz+O0YRce9LHyYUDw34tvJcETHR0PNuE7p84J7kV02VLAOV+B1094Q=="
     },
     "node_modules/minecraft-folder-path": {
       "version": "1.2.0",
@@ -1871,11 +1867,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/minecraft-protocol/node_modules/minecraft-data": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-3.24.0.tgz",
-      "integrity": "sha512-Y7iAajuoshzQcYITkHITn4Ib/XsAc4I6Bacwy0oW/wRhjaqxgdokL0q4IqM+gVsrYg25tTvN2aZnG1Pk+zQ5wA=="
     },
     "node_modules/mineflayer": {
       "version": "4.5.1",
@@ -1913,6 +1904,11 @@
         "vec3": "^0.1.7"
       }
     },
+    "node_modules/mineflayer-antiafk/node_modules/minecraft-data": {
+      "version": "2.221.0",
+      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-2.221.0.tgz",
+      "integrity": "sha512-0AhqzbIKb6WqPSF6qBevaPryeWOz545hLxt6q+gfJF8YIQX/YfkyX/nXWhl+pSIS2rTBcQ0RJkRCtTeRzQwHDA=="
+    },
     "node_modules/mineflayer-antiafk/node_modules/mineflayer-auto-eat": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/mineflayer-auto-eat/-/mineflayer-auto-eat-2.3.3.tgz",
@@ -1925,11 +1921,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/mineflayer-auto-eat/-/mineflayer-auto-eat-3.3.0.tgz",
       "integrity": "sha512-yxpvxyazKrgoB05X2vzHGzrA2dkVDccFfkeCOj3Os5QKgUBnYjvRkF3Jo4dzWW+8TInra4Eq7vCuPwZP9Sykdg=="
-    },
-    "node_modules/mineflayer/node_modules/minecraft-data": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-3.19.0.tgz",
-      "integrity": "sha512-qOrgBMIekOblZ6YJGnxzWIDSGJkdLIlrZlRdi3/9MVMV2r80t4Ccq/Tf5azOPmpCetJ2tqbq96oeIG90tV+s6A=="
     },
     "node_modules/mineflayer/node_modules/prismarine-biome": {
       "version": "1.3.0",
@@ -2298,11 +2289,6 @@
         "prismarine-registry": "^1.1.0"
       }
     },
-    "node_modules/prismarine-block/node_modules/minecraft-data": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-3.19.0.tgz",
-      "integrity": "sha512-qOrgBMIekOblZ6YJGnxzWIDSGJkdLIlrZlRdi3/9MVMV2r80t4Ccq/Tf5azOPmpCetJ2tqbq96oeIG90tV+s6A=="
-    },
     "node_modules/prismarine-block/node_modules/prismarine-biome": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/prismarine-biome/-/prismarine-biome-1.3.0.tgz",
@@ -2341,11 +2327,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/prismarine-chunk/node_modules/minecraft-data": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-3.19.0.tgz",
-      "integrity": "sha512-qOrgBMIekOblZ6YJGnxzWIDSGJkdLIlrZlRdi3/9MVMV2r80t4Ccq/Tf5azOPmpCetJ2tqbq96oeIG90tV+s6A=="
-    },
     "node_modules/prismarine-chunk/node_modules/prismarine-biome": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/prismarine-biome/-/prismarine-biome-1.3.0.tgz",
@@ -2366,11 +2347,6 @@
         "prismarine-registry": "^1.4.0",
         "vec3": "^0.1.4"
       }
-    },
-    "node_modules/prismarine-entity/node_modules/minecraft-data": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-3.19.0.tgz",
-      "integrity": "sha512-qOrgBMIekOblZ6YJGnxzWIDSGJkdLIlrZlRdi3/9MVMV2r80t4Ccq/Tf5azOPmpCetJ2tqbq96oeIG90tV+s6A=="
     },
     "node_modules/prismarine-item": {
       "version": "1.12.1",
@@ -2398,11 +2374,6 @@
         "prismarine-nbt": "^2.0.0",
         "vec3": "^0.1.7"
       }
-    },
-    "node_modules/prismarine-physics/node_modules/minecraft-data": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-3.19.0.tgz",
-      "integrity": "sha512-qOrgBMIekOblZ6YJGnxzWIDSGJkdLIlrZlRdi3/9MVMV2r80t4Ccq/Tf5azOPmpCetJ2tqbq96oeIG90tV+s6A=="
     },
     "node_modules/prismarine-provider-anvil": {
       "version": "2.7.0",
@@ -2440,11 +2411,6 @@
         "minecraft-data": "^3.0.0",
         "prismarine-nbt": "^2.0.0"
       }
-    },
-    "node_modules/prismarine-registry/node_modules/minecraft-data": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-3.19.0.tgz",
-      "integrity": "sha512-qOrgBMIekOblZ6YJGnxzWIDSGJkdLIlrZlRdi3/9MVMV2r80t4Ccq/Tf5azOPmpCetJ2tqbq96oeIG90tV+s6A=="
     },
     "node_modules/prismarine-windows": {
       "version": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "node-fetch": "^2.6.9",
     "node-notifier": "^10.0.1",
     "prismarine-chat": "^1.8.0",
-    "prismarine-provider-anvil": "^2.7.0"
+    "prismarine-provider-anvil": "^2.7.0",
+    "minecraft-data": "^3.0.0"
   },
   "devDependencies": {
     "eslint": "^8.33.0",


### PR DESCRIPTION
If not included, (p)npm will complain about an issue with a peer dependency from `prismarine-biome`.