### PR TITLE
fix: debug-info crash if log folder doens't exist

### DIFF
--- a/scripts/debugFetch.js
+++ b/scripts/debugFetch.js
@@ -44,7 +44,7 @@ const filesToHash = [ // Paths of files to hash
 const lastModified = getLastModifiedFile(filesToHash);
 
 /** Logs */
-const logDirs = getDirectories("./log"); // Array of all directories in ./log
+const logDirs = fs.existsSync("./log") ? getDirectories("./log") : []; // Array of all directories in ./log
 
 /** Tests*/
 const isConfigValid = isValidJson5("./config.json"); // Whether ./config.json can be parsed


### PR DESCRIPTION
Prior to this commit, if the `./.log` happened to not exist, then debugFetch.js would crash because `fs.readdirSync` would've been sent an undefined parameter, which was not properly handled. Now, it checks if the directory exists in the first place. If it does, then cool, it set it to the log files array. If not, it sets it to an empty array, which is compatible with the `.forEach()` function since it will just stop immediately cause there is nothing in the array